### PR TITLE
Change README to reflect server.py renaming

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Runner is a simple, yet powerful tool that allows you to run code in a variety o
 
 clone the repo and cd into the runner directory.
 
-run /lib/server.py on a linux system. sorry windows.
+run `lib/main.py` on a linux system or wsl. sorry windows.
 spawn out Code from Charlie's public folder inside of a world in resonite and hit the purple button to connect to the server.
 once you hear tada.wav, you are connected and can start running code.
 


### PR DESCRIPTION
Changed the readme to say `lib/main.py` instead of `/lib/server.py` to reflect renaming of server.py to main.py and so people don't put that first / and get a error